### PR TITLE
Fix name of field

### DIFF
--- a/src/modules/measurement/MeasurementTable.vue
+++ b/src/modules/measurement/MeasurementTable.vue
@@ -80,14 +80,14 @@ export default {
 				},
 				{
 					name: t('health', 'Blood pressure systolic'),
-					columnId: 'systolic',
+					columnId: 'bloodPressureS',
 					type: 'number',
 					show: this.person.measurementColumnBloodPres,
 					min: 0,
 				},
 				{
 					name: t('health', 'Blood pressure diastolic'),
-					columnId: 'diastolic',
+					columnId: 'bloodPressureD',
 					type: 'number',
 					show: this.person.measurementColumnBloodPres,
 					min: 0,


### PR DESCRIPTION
The field id is used to define the name of the field sent to the API and must be equal to the name of the column 