### PR TITLE
Remove unrecognized command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ dist:
 source:
 	rm -rf $(source_build_directory)
 	mkdir -p $(source_build_directory)
-	tar --disable-copyfile -c \
+	COPYFILE_DISABLE=1 tar -c \
 	--exclude="./.gitignore" \
 	--exclude="./.git" \
 	--exclude="./.idea" \
@@ -138,7 +138,7 @@ source:
 appstore:
 	rm -rf $(appstore_build_directory)
 	mkdir -p $(appstore_build_directory)
-	tar -c \
+	COPYFILE_DISABLE=1 tar -c \
 	--exclude="./.gitignore" \
 	--exclude="./.git" \
 	--exclude="./.idea" \

--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,6 @@ appstore:
 	rm -rf $(appstore_build_directory)
 	mkdir -p $(appstore_build_directory)
 	tar -c \
- 	--disable-copyfile \
 	--exclude="./.gitignore" \
 	--exclude="./.git" \
 	--exclude="./.idea" \


### PR DESCRIPTION
This PR solve the follow error:

```
tar: unrecognized option '--disable-copyfile'
Try 'tar --help' or 'tar --usage' for more information.
make: *** [Makefile:141: appstore] Error 64
```