### PR TITLE
#94 Fix bmi calculation when weightUnit is lb

### DIFF
--- a/src/modules/weight/MixinBmi.js
+++ b/src/modules/weight/MixinBmi.js
@@ -10,7 +10,13 @@ export default {
 				return null
 			}
 			const s = person.size / 100
-			const bmi = weight / (s * s)
+			
+			if (person.weightUnit === 'lb' {
+				const bmi = (weight / 2.20462262) / (s * s)
+			}
+			else {
+				const bmi = weight / (s * s)
+			}
 			// console.debug('bmi: ' + bmi)
 			return Math.round(bmi)
 		},


### PR DESCRIPTION
BMI is calculated correctly when user records their weight in pounds (lb).