### PR TITLE
Add support for sharing persons

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -36,6 +36,13 @@ return [
 		['name' => 'persons#data', 'url' => '/person/{personId}/data', 'verb' => 'GET'],
 		['name' => 'persons_api#data', 'url' => '/api/1/person/{personId}/data', 'verb' => 'GET'],
 
+		['name' => 'persons#addAcl', 'url' => '/persons/{personId}/acl', 'verb' => 'POST'],
+		['name' => 'persons#updateAcl', 'url' => '/persons/{personId}/acl/{aclId}', 'verb' => 'PUT'],
+		['name' => 'persons#deleteAcl', 'url' => '/persons/{personId}/acl/{aclId}', 'verb' => 'DELETE'],
+		['name' => 'persons_api#addAcl', 'url' => '/api/1/persons/{personId}/acl', 'verb' => 'POST'],
+		['name' => 'persons_api#updateAcl', 'url' => '/api/1/persons/{personId}/acl/{aclId}', 'verb' => 'PUT'],
+		['name' => 'persons_api#deleteAcl', 'url' => '/api/1/persons/{personId}/acl/{aclId}', 'verb' => 'DELETE'],
+
 		// weight data
 		['name' => 'weightdata#findByPerson',	'url' => '/weight/dataset/person/{personId}',	'verb' => 'GET'],
 		['name' => 'weightdata#create',	'url' => '/weight/dataset/person/{personId}',	'verb' => 'POST'],

--- a/js/health-main.js.LICENSE.txt
+++ b/js/health-main.js.LICENSE.txt
@@ -302,6 +302,28 @@ License: MIT
  */
 
 /**
+ * @copyright Copyright (c) 2019 Greta Doci <gretadoci@gmail.com>
+ *
+ * @author Greta Doci <gretadoci@gmail.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
  * @copyright Copyright (c) 2019 John Molakvoæ <skjnldsv@protonmail.com>
  *
  * @author John Molakvoæ <skjnldsv@protonmail.com>
@@ -321,6 +343,27 @@ License: MIT
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
+ */
+
+/**
+ * @copyright Copyright (c) 2019 John Molakvoæ <skjnldsv@protonmail.com>
+ *
+ * @author John Molakvoæ <skjnldsv@protonmail.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 /**
@@ -371,6 +414,28 @@ License: MIT
  * @copyright Copyright (c) 2019 Julius Härtl <jus@bitgrid.net>
  *
  * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * @copyright Copyright (c) 2019 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
  * @author John Molakvoæ <skjnldsv@protonmail.com>
  *
  * @license GNU AGPL version 3 or any later version
@@ -383,6 +448,28 @@ License: MIT
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * @copyright Copyright (c) 2019 Marco Ambrosini <marcoambrosini@pm.me>
+ *
+ * @author Marco Ambrosini <marcoambrosini@pm.me>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
@@ -558,6 +645,28 @@ License: MIT
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * @copyright Copyright (c) 2020 Marco Ambrosini <marcoambrosini@pm.me>
+ *
+ * @author Marco Ambrosini <marcoambrosini@pm.me>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
@@ -602,6 +711,28 @@ License: MIT
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * @copyright Copyright (c) 2020 Raimund Schlüßler <raimund.schluessler@mailbox.org>
+ *
+ * @author Raimund Schlüßler <raimund.schluessler@mailbox.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
@@ -625,6 +756,94 @@ License: MIT
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * @copyright Copyright (c) 2021 John Molakvoæ <skjnldsv@protonmail.com>
+ *
+ * @author John Molakvoæ <skjnldsv@protonmail.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * @copyright Copyright (c) 2021 Marco Ambrosini <marcoambrosini@pm.me>
+ *
+ * @author Marco Ambrosini <marcoambrosini@pm.me>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * @copyright Copyright (c) 2021 Marco Ambrosini <marcoambrosini@pm.me>
+ *
+ * @author Marco Ambrosini <marcoambrosini@pm.me>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * @copyright Copyright (c) 2021 Vincent Petry <vincent@nextcloud.com>
+ *
+ * @author Vincent Petry <vincent@nextcloud.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License

--- a/lib/Controller/PersonsApiController.php
+++ b/lib/Controller/PersonsApiController.php
@@ -131,9 +131,9 @@ class PersonsApiController extends ApiController {
 	 * @CORS
 	 * @NoCSRFRequired
 
-	 * @param $id
+	 * @param $personId
+	 * @param $aclId
 	 * @param $permissionEdit
-	 * @param $permissionShare
 	 * @param $permissionManage
 	 * @return DataResponse
 	 */

--- a/lib/Controller/PersonsApiController.php
+++ b/lib/Controller/PersonsApiController.php
@@ -109,4 +109,48 @@ class PersonsApiController extends ApiController {
 	{
 		return new DataResponse($this->personsService->updatePerson($id, $key, $value));
 	}
+
+	/**
+	 * @NoAdminRequired
+	 * @CORS
+	 * @NoCSRFRequired
+
+	 * @param $personId
+	 * @param $type
+	 * @param $participant
+	 * @param $permissionEdit
+	 * @param $permissionManage
+	 * @return DataResponse
+	 */
+	public function addAcl(int $personId, int $type, string $participant, bool $permissionEdit, bool $permissionManage) {
+		return new DataResponse($this->personsService->addAcl($personId, $type, $participant, $permissionEdit, $permissionManage));
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @CORS
+	 * @NoCSRFRequired
+
+	 * @param $id
+	 * @param $permissionEdit
+	 * @param $permissionShare
+	 * @param $permissionManage
+	 * @return DataResponse
+	 */
+	public function updateAcl(int $personId, int $aclId, bool $permissionEdit, bool $permissionManage) {
+		return new DataResponse($this->personsService->updateAcl($personId, $aclId, $permissionEdit, $permissionManage));
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @CORS
+	 * @NoCSRFRequired
+
+	 * @param $personId
+	 * @param $aclId
+	 * @return DataResponse
+	 */
+	public function deleteAcl(int $personId, int $aclId) {
+		return new DataResponse($this->personsService->deleteAcl($personId, $aclId));
+	}
 }

--- a/lib/Controller/PersonsController.php
+++ b/lib/Controller/PersonsController.php
@@ -101,4 +101,39 @@ class PersonsController extends Controller {
 	{
 		return new DataResponse($this->personsService->updatePerson($id, $key, $value));
 	}
+
+	/**
+	 * @NoAdminRequired
+	 * @param $personId
+	 * @param $type
+	 * @param $participant
+	 * @param $permissionEdit
+	 * @param $permissionManage
+	 * @return DataResponse
+	 */
+	public function addAcl(int $personId, int $type, string $participant, bool $permissionEdit, bool $permissionManage) {
+		return new DataResponse($this->personsService->addAcl($personId, $type, $participant, $permissionEdit, $permissionManage));
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @param $id
+	 * @param $permissionEdit
+	 * @param $permissionShare
+	 * @param $permissionManage
+	 * @return DataResponse
+	 */
+	public function updateAcl(int $personId, int $aclId, bool $permissionEdit, bool $permissionManage) {
+		return new DataResponse($this->personsService->updateAcl($personId, $aclId, $permissionEdit, $permissionManage));
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @param $personId
+	 * @param $aclId
+	 * @return DataResponse
+	 */
+	public function deleteAcl(int $personId, int $aclId) {
+		return new DataResponse($this->personsService->deleteAcl($personId, $aclId));
+	}
 }

--- a/lib/Controller/PersonsController.php
+++ b/lib/Controller/PersonsController.php
@@ -117,9 +117,9 @@ class PersonsController extends Controller {
 
 	/**
 	 * @NoAdminRequired
-	 * @param $id
+	 * @param $personId
+	 * @param $aclId
 	 * @param $permissionEdit
-	 * @param $permissionShare
 	 * @param $permissionManage
 	 * @return DataResponse
 	 */

--- a/lib/Db/Acl.php
+++ b/lib/Db/Acl.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * @copyright Copyright (c) 2020 Florian Steffens <flost-dev@mailbox.org>
+ *
+ * @author Marcus Nitzschke <mail@kendix.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Health\Db;
+
+use JsonSerializable;
+
+use OCP\AppFramework\Db\Entity;
+
+class Acl extends Entity implements JsonSerializable {
+	public const PERMISSION_READ = 0;
+	public const PERMISSION_EDIT = 1;
+	public const PERMISSION_MANAGE = 2;
+
+	public const PERMISSION_TYPE_USER = 0;
+	public const PERMISSION_TYPE_GROUP = 1;
+
+	protected $participant;
+	protected $type;
+	protected $personId;
+	protected $permissionEdit = false;
+	protected $permissionManage = false;
+
+	public function __construct() {
+		$this->addType('id', 'integer');
+		$this->addType('personId', 'integer');
+		$this->addType('permissionEdit', 'boolean');
+		$this->addType('permissionManage', 'boolean');
+		$this->addType('type', 'integer');
+	}
+
+	public function getPermission($permission) {
+		switch ($permission) {
+			case self::PERMISSION_READ:
+				return true;
+			case self::PERMISSION_EDIT:
+				return $this->getPermissionEdit() ?? false;
+			case self::PERMISSION_MANAGE:
+				return $this->getPermissionManage() ?? false;
+		}
+		return false;
+	}
+
+	public function jsonSerialize(): array
+	{
+        return [
+			'id' => $this->id,
+			'personId' => $this->personId,
+			'permissionEdit' => $this->permissionEdit,
+			'permissionManage' => $this->permissionManage,
+			'type' => $this->type,
+			'participant' => $this->participant
+        ];
+    }
+}

--- a/lib/Db/AclMapper.php
+++ b/lib/Db/AclMapper.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * @copyright Copyright (c) 2020 Florian Steffens <flost-dev@mailbox.org>
+ *
+ * @author Marcus Nitzschke <mail@kendix.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Health\Db;
+
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\MultipleObjectsReturnedException;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use OCP\IUserManager;
+use OCP\IGroupManager;
+use OCP\AppFramework\Db\QBMapper;
+use Psr\Log\LoggerInterface;
+
+class AclMapper extends QBMapper {
+
+	private $userManager;
+	private $groupManager;
+	protected $logger;
+
+	public function __construct(
+		IDBConnection $db,
+		IUserManager $userManager,
+		IGroupManager $groupManager
+		, LoggerInterface $logger
+	) {
+		parent::__construct($db, 'health_persons_acl', Acl::class);
+		$this->userManager = $userManager;
+		$this->groupManager = $groupManager;
+				$this->logger = $logger;
+	}
+
+	public function findAllByPerson($personId) {
+		$qb = $this->db->getQueryBuilder();
+
+        $qb->select('*')
+           ->from($this->getTableName())
+           ->where(
+            $qb->expr()->eq('person_id', $qb->createNamedParameter($personId))
+           );
+
+		$entities = $this->findEntities($qb);
+		foreach ($entities as $acl) {
+			$this->mapParticipant($acl);
+		}
+		return $entities;
+	}
+
+	public function findAll() {
+		$qb = $this->db->getQueryBuilder();
+
+        $qb->select('*')
+			->from($this->getTableName());
+
+		$entities = $this->findEntities($qb);
+		foreach ($entities as $acl) {
+			$this->mapParticipant($acl);
+		}
+		return $entities;
+	}
+
+	public function find(int $id) {
+        $qb = $this->db->getQueryBuilder();
+
+		$qb->select('*')
+			->from($this->getTableName())
+			->where(
+				$qb->expr()->eq('id', $qb->createNamedParameter($id))
+			);
+
+        return $this->findEntity($qb);
+    }
+
+	public function mapParticipant(Acl $acl) {
+		if ($acl->getType() === Acl::PERMISSION_TYPE_USER) {
+			$user = $this->userManager->get($acl->getParticipant());
+			if ($user !== null) {
+				$acl->setParticipant([
+					'uid' => $user->getUID(),
+					'displayname' => $user->getDisplayName(),
+					'type' => 0
+				]);
+				return $acl;
+			}
+			return null;
+		}
+		if ($acl->getType() === Acl::PERMISSION_TYPE_GROUP) {
+			$group = $this->groupManager->get($acl->getParticipant());
+			if ($group !== null) {
+				$acl->setParticipant([
+					'uid' => $group->getGID(),
+					'displayname' => $group->getDisplayName(),
+					'type' => 1
+				]);
+				return $acl;
+			}
+			return null;
+		}
+	}
+}

--- a/lib/Db/AclMapper.php
+++ b/lib/Db/AclMapper.php
@@ -30,34 +30,30 @@ use OCP\IDBConnection;
 use OCP\IUserManager;
 use OCP\IGroupManager;
 use OCP\AppFramework\Db\QBMapper;
-use Psr\Log\LoggerInterface;
 
 class AclMapper extends QBMapper {
 
 	private $userManager;
 	private $groupManager;
-	protected $logger;
 
 	public function __construct(
 		IDBConnection $db,
 		IUserManager $userManager,
 		IGroupManager $groupManager
-		, LoggerInterface $logger
 	) {
 		parent::__construct($db, 'health_persons_acl', Acl::class);
 		$this->userManager = $userManager;
 		$this->groupManager = $groupManager;
-				$this->logger = $logger;
 	}
 
 	public function findAllByPerson($personId) {
 		$qb = $this->db->getQueryBuilder();
 
-        $qb->select('*')
-           ->from($this->getTableName())
-           ->where(
-            $qb->expr()->eq('person_id', $qb->createNamedParameter($personId))
-           );
+		$qb->select('*')
+			->from($this->getTableName())
+			->where(
+				$qb->expr()->eq('person_id', $qb->createNamedParameter($personId))
+			);
 
 		$entities = $this->findEntities($qb);
 		foreach ($entities as $acl) {

--- a/lib/Db/Person.php
+++ b/lib/Db/Person.php
@@ -41,6 +41,8 @@ class Person extends Entity implements JsonSerializable {
 	protected $shared;
 	protected $sharedReadonly;
 	protected $currency;
+	protected $acl;
+	protected $permissions;
 
     // modules
     protected $enabledModuleWeight;
@@ -200,6 +202,9 @@ class Person extends Entity implements JsonSerializable {
 			'shared' => $this->shared,
 			'sharedReadonly' => $this->sharedReadonly,
 			'currency' => $this->currency,
+			/** @var Acl[]|null */
+			'acl' => $this->acl ?? [],
+			'permissions' => $this->permissions ?? [],
 
 			// modules
             'enabledModuleWeight' => $this->enabledModuleWeight,

--- a/lib/Db/PersonMapper.php
+++ b/lib/Db/PersonMapper.php
@@ -46,7 +46,7 @@ class PersonMapper extends QBMapper {
 		IGroupManager $groupManager,
 		PermissionHelperService $permissionHelper
 	) {
-        parent::__construct($db, 'health_persons', Person::class);
+		parent::__construct($db, 'health_persons', Person::class);
 		$this->aclMapper = $aclMapper;
 		$this->groupManager = $groupManager;
 		$this->permissionHelper = $permissionHelper;
@@ -54,45 +54,45 @@ class PersonMapper extends QBMapper {
 
     public function find(int $id, string $userId = ""): ?Entity
 	{
-        $qb = $this->db->getQueryBuilder();
+		$qb = $this->db->getQueryBuilder();
 
-        $qb->select('p.*');
+		$qb->select('p.*');
 		$qb->from($this->getTableName(), 'p');
 		if($userId !== "") {
 			$qb->leftJoin('p', 'health_persons_acl', 'acl', 'p.id=acl.person_id');
 		}
 		$qb->where( $qb->expr()->eq('p.id', $qb->createNamedParameter($id)) );
 
-        if($userId !== "") {
-            $qb->andWhere( $qb->expr()->orX(
+		if($userId !== "") {
+			$qb->andWhere( $qb->expr()->orX(
 				$qb->expr()->eq('acl.participant', $qb->createNamedParameter($userId) ),
 				$qb->expr()->eq('p.user_id', $qb->createNamedParameter($userId) )
 			));
-        }
+		}
 		$qb->groupBy('p.id');
 		try {
 			return $this->findEntity($qb);
 		} catch (DoesNotExistException | MultipleObjectsReturnedException $e) {
-        	return null;
+			return null;
 		}
 	}
 
     public function findAll(string $userId): array
 	{
-        $qb = $this->db->getQueryBuilder();
+		$qb = $this->db->getQueryBuilder();
 
 		// get all acl's
 		$acls = $this->aclMapper->findAll();
 		$personIds = $this->permissionHelper->getSharedPersonsOfCurrentUser($acls);
 
-        $qb->select('*')
+		$qb->select('*')
 			->from($this->getTableName())
 			->where($qb->expr()->eq('user_id', $qb->createNamedParameter($userId)));
 
 		if (count($personIds) > 0) {
 			$qb->orWhere("id IN (".implode(",", $personIds).")");
 		}
-        return $this->findEntities($qb);
-    }
+		return $this->findEntities($qb);
+	}
 
 }

--- a/lib/Migration/Version1600Date20220715000000.php
+++ b/lib/Migration/Version1600Date20220715000000.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * @copyright Copyright (c) 2020 Florian Steffens <flost-dev@mailbox.org>
+ *
+ * @author Marcus Nitzschke <mail@kendix.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\Health\Migration;
+
+use Closure;
+use Doctrine\DBAL\Schema\SchemaException;
+use Doctrine\DBAL\Types\Type;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\IDBConnection;
+use OCP\Migration\SimpleMigrationStep;
+use OCP\Migration\IOutput;
+
+class Version1600Date20220715000000 extends SimpleMigrationStep {
+
+	/** @var IDBConnection */
+	protected $connection;
+
+	public function __construct(IDBConnection $connection) {
+	  $this->connection = $connection;
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 * @throws SchemaException
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
+	{
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$tableName = 'health_persons_acl';
+		if (!$schema->hasTable($tableName)) {
+			$table = $schema->createTable($tableName);
+			$table->addColumn('id', 'integer', [
+				'autoincrement' => true,
+				'notnull' => true,
+				'length' => 4,
+			]);
+			$table->addColumn('person_id', 'bigint', [
+				'notnull' => true,
+				'length' => 8,
+			]);
+			$table->addColumn('type', 'integer', [
+				'notnull' => true,
+				'length' => 4,
+			]);
+			$table->addColumn('participant', 'string', [
+				'notnull' => true,
+				'length' => 64,
+			]);
+			$table->addColumn('permission_edit', 'boolean', [
+				'notnull' => false,
+				'default' => false,
+			]);
+			$table->addColumn('permission_manage', 'boolean', [
+				'notnull' => false,
+				'default' => false,
+			]);
+			$table->setPrimaryKey(['id']);
+			$table->addUniqueIndex(['person_id', 'type', 'participant'], 'health_persons_acl_uq_i');
+			$table->addIndex(['person_id'], 'health_persons_acl_idx_i');
+		}
+
+		return $schema;
+	}
+}

--- a/lib/Services/PermissionHelperService.php
+++ b/lib/Services/PermissionHelperService.php
@@ -1,0 +1,93 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2020 Florian Steffens <flost-dev@mailbox.org>
+ *
+ * @author Marcus Nitzschke <mail@kendix.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Health\Services;
+
+use Exception;
+use OCA\Health\Db\Acl;
+use OCA\Health\Db\Person;
+use OCP\IGroupManager;
+
+class PermissionHelperService {
+
+	protected $userId;
+	private $groupManager;
+
+	public function __construct(
+		$userId,
+		IGroupManager $groupManager
+	) {
+		$this->userId = $userId;
+		$this->groupManager = $groupManager;
+	}
+
+	public function matchPermissions(Person $person) {
+		$owner = $person->getUserId() === $this->userId;
+		$acls = $person->getAcl() ?? [];
+		return [
+			Acl::PERMISSION_READ => $owner || $this->userCan($acls, Acl::PERMISSION_READ),
+			Acl::PERMISSION_EDIT => $owner || $this->userCan($acls, Acl::PERMISSION_EDIT),
+			Acl::PERMISSION_MANAGE => $owner || $this->userCan($acls, Acl::PERMISSION_MANAGE),
+		];
+	}
+
+	/**
+	 * Check if permission matches the acl rules for current user and groups
+	 *
+	 * @param Acl[] $acls
+	 * @param $permission
+	 * @return bool
+	 */
+	public function userCan(array $acls, $permission): bool {
+		foreach ($acls as $acl) {
+			if ($acl->getType() === Acl::PERMISSION_TYPE_USER && $acl->getParticipant()["uid"] === $this->userId) {
+				return $acl->getPermission($permission);
+			}
+			if ($acl->getType() === Acl::PERMISSION_TYPE_GROUP && $this->groupManager->isInGroup($this->userId, $acl->getParticipant()["uid"])) {
+				return $acl->getPermission($permission);
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Get all person ids that are shared with the current user.
+	 *
+	 * @param Acl[] $acls
+	 * @return array
+	 */
+	public function getSharedPersonsOfCurrentUser(array $acls): array {
+		$personIds = array();
+		foreach($acls as $acl) {
+			if ($acl->getType() == Acl::PERMISSION_TYPE_USER && $acl->getParticipant()["uid"] == $this->userId) {
+				$personIds[] = $acl->getPersonId();
+			}
+			if ($acl->getType() == Acl::PERMISSION_TYPE_GROUP && $this->groupManager->isInGroup($this->userId, $acl->getParticipant()["uid"])) {
+				$personIds[] = $acl->getPersonId();
+			}
+		}
+
+		return $personIds;
+	}
+}

--- a/lib/Services/PermissionHelperService.php
+++ b/lib/Services/PermissionHelperService.php
@@ -42,6 +42,12 @@ class PermissionHelperService {
 		$this->groupManager = $groupManager;
 	}
 
+	/**
+	 * Resolved the permission of a person according to existing ACL's.
+	 *
+	 * @param Person $person
+	 * @return array
+	 */
 	public function matchPermissions(Person $person) {
 		$owner = $person->getUserId() === $this->userId;
 		$acls = $person->getAcl() ?? [];
@@ -53,7 +59,7 @@ class PermissionHelperService {
 	}
 
 	/**
-	 * Check if permission matches the acl rules for current user and groups
+	 * Check if permission matches the acl rules for current user and groups.
 	 *
 	 * @param Acl[] $acls
 	 * @param $permission

--- a/lib/Services/PermissionService.php
+++ b/lib/Services/PermissionService.php
@@ -56,22 +56,22 @@ class PermissionService {
 	{
 		try {
 			// check for ownership
-            if($this->personMapper->find($destinationPersonId, $sourceUserId) !== null) {
-            	return true;
-            }
-        } catch(Exception $e) {
+			if($this->personMapper->find($destinationPersonId, $sourceUserId) !== null) {
+				return true;
+			}
+		} catch(Exception $e) {
 			$context = [
 				'personId' => $destinationPersonId,
 				'userId' => $sourceUserId
 			];
 			$this->logger->error('User tries to fetch data from personId that is not permitted.', $context);
-        }
+		}
 		// check ACL's
 		$acls = $this->aclMapper->findAllByPerson($destinationPersonId);
 		if ($this->permissionHelper->userCan($acls, Acl::PERMISSION_EDIT)) {
 			return true;
 		}
-        return false;
+		return false;
 	}
 
 	public function weightData($id, $userId): bool

--- a/lib/Services/PersonsService.php
+++ b/lib/Services/PersonsService.php
@@ -216,7 +216,7 @@ class PersonsService {
 		];
 	}
 
-		/**
+	/**
 	 * @param $personId
 	 * @param $type
 	 * @param $participant
@@ -225,7 +225,6 @@ class PersonsService {
 	 * @return \OCP\AppFramework\Db\Entity
 	 */
 	public function addAcl(int $personId, int $type, string $participant, bool $edit, bool $manage) {
-		// check if user is 'owner' of this person to allow sharing
 		if( !$this->permissionService->personData($personId, $this->userId)) {
 			return null;
 		}
@@ -236,9 +235,8 @@ class PersonsService {
 		$acl->setParticipant($participant);
 		$acl->setPermissionEdit($edit);
 		$acl->setPermissionManage($manage);
-		$newAcl = $this->aclMapper->insert($acl);
 
-		return $this->aclMapper->mapParticipant($newAcl);
+		return $this->aclMapper->mapParticipant($this->aclMapper->insert($acl));
 	}
 
 	/**
@@ -256,16 +254,15 @@ class PersonsService {
 		}
 
 		$acl = $this->aclMapper->find($aclId);
-		//[$edit, $share, $manage] = $this->applyPermissions($acl->getBoardId(), $edit, $share, $manage);
 		$acl->setPermissionEdit($edit);
 		$acl->setPermissionManage($manage);
-		$updatedAcl = $this->aclMapper->mapParticipant($this->aclMapper->update($acl));
 
-		return $updatedAcl;
+		return $this->aclMapper->mapParticipant($this->aclMapper->update($acl));
 	}
 
 	/**
-	 * @param $id
+	 * @param $personId
+	 * @param $aclId
 	 * @return \OCP\AppFramework\Db\Entity
 	 * @throws DoesNotExistException
 	 * @throws \OCA\Deck\NoPermissionException
@@ -277,9 +274,8 @@ class PersonsService {
 			return null;
 		}
 		$acl = $this->aclMapper->find($aclId);
-		$delete = $this->aclMapper->delete($acl);
 
-		return $delete;
+		return $this->aclMapper->delete($acl);
 	}
 
 }

--- a/lib/Services/PersonsService.php
+++ b/lib/Services/PersonsService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
  * @copyright Copyright (c) 2020 Florian Steffens <flost-dev@mailbox.org>
  *
  * @author Florian Steffens <flost-dev@mailbox.org>
+ * @author Marcus Nitzschke <mail@kendix.org>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -24,6 +25,8 @@ declare(strict_types=1);
 
 namespace OCA\Health\Services;
 
+use OCA\Health\Db\Acl;
+use OCA\Health\Db\AclMapper;
 use OCA\Health\Db\PersonMapper;
 use OCA\Health\Db\Person;
 use Exception;
@@ -32,6 +35,7 @@ use OCP\IUserManager;
 
 class PersonsService {
 
+	protected $aclMapper;
 	protected $personMapper;
 	protected $weightdataService;
 	protected $sleepdataService;
@@ -40,13 +44,16 @@ class PersonsService {
 	protected $activitiesdataService;
 	protected $userId;
 	protected $formatHelperService;
+	protected $permissionHelper;
 	protected $permissionService;
 	protected $userManager;
 
-	public function __construct(PersonMapper $personMapper,
+	public function __construct(AclMapper $aclMapper,
+								PersonMapper $personMapper,
 								$userId,
 								WeightdataService $weightdataService,
 								FormatHelperService $formatHelperService,
+								PermissionHelperService $permissionHelper,
 								PermissionService $permissionService,
 								IUserManager $userManager,
 								FeelingdataService $feelingdataService,
@@ -54,10 +61,12 @@ class PersonsService {
 								MeasurementdataService $measurementdataService,
 								ActivitiesdataService $activitiesdataService
 	) {
+		$this->aclMapper = $aclMapper;
 		$this->personMapper = $personMapper;
 		$this->userId = $userId;
 		$this->weightdataService = $weightdataService;
 		$this->formatHelperService = $formatHelperService;
+		$this->permissionHelper = $permissionHelper;
 		$this->permissionService = $permissionService;
 		$this->userManager = $userManager;
 		$this->sleepdataService = $sleepdataService;
@@ -73,6 +82,15 @@ class PersonsService {
 			$user = $this->userManager->get($this->userId);
 			$this->createPerson( $user->getDisplayName() );
 			$persons = $this->personMapper->findAll($this->userId);
+		}
+		foreach ($persons as $person) {
+			$person->setAcl($this->aclMapper->findAllByPerson($person->getId()));
+			$permissions = $this->permissionHelper->matchPermissions($person);
+			$person->setPermissions([
+				'PERMISSION_READ' => $permissions[Acl::PERMISSION_READ] ?? false,
+				'PERMISSION_EDIT' => $permissions[Acl::PERMISSION_EDIT] ?? false,
+				'PERMISSION_MANAGE' => $permissions[Acl::PERMISSION_MANAGE] ?? false,
+			]);
 		}
 		return $persons;
 	}
@@ -111,7 +129,16 @@ class PersonsService {
 		$p->setActivitiesColumnDuration(true);
 		$p->setActivitiesColumnCategory(true);
 		$p->setActivitiesDistanceUnit('m');
-		return $this->personMapper->insert($p);
+
+		$person = $this->personMapper->insert($p);
+		$permissions = $this->permissionHelper->matchPermissions($person);
+		$person->setPermissions([
+			'PERMISSION_READ' => $permissions[Acl::PERMISSION_READ] ?? false,
+			'PERMISSION_EDIT' => $permissions[Acl::PERMISSION_EDIT] ?? false,
+			'PERMISSION_MANAGE' => $permissions[Acl::PERMISSION_MANAGE] ?? false,
+		]);
+
+		return $person;
 	}
 
 	public function deletePerson($id) {
@@ -168,6 +195,14 @@ class PersonsService {
 		$person->{$method}($this->formatHelperService->typeCastByEntity($key, $value, $person));
 		$this->personMapper->update($person);
 
+		$person->setAcl($this->aclMapper->findAllByPerson($person->getId()));
+		$permissions = $this->permissionHelper->matchPermissions($person);
+		$person->setPermissions([
+			'PERMISSION_READ' => $permissions[Acl::PERMISSION_READ] ?? false,
+			'PERMISSION_EDIT' => $permissions[Acl::PERMISSION_EDIT] ?? false,
+			'PERMISSION_MANAGE' => $permissions[Acl::PERMISSION_MANAGE] ?? false,
+		]);
+
 		return $person;
 	}
 
@@ -179,6 +214,72 @@ class PersonsService {
 		return [
 			'lastWeight' => $this->weightdataService->getLastWeight($personId)
 		];
+	}
+
+		/**
+	 * @param $personId
+	 * @param $type
+	 * @param $participant
+	 * @param $edit
+	 * @param $manage
+	 * @return \OCP\AppFramework\Db\Entity
+	 */
+	public function addAcl(int $personId, int $type, string $participant, bool $edit, bool $manage) {
+		// check if user is 'owner' of this person to allow sharing
+		if( !$this->permissionService->personData($personId, $this->userId)) {
+			return null;
+		}
+
+		$acl = new Acl();
+		$acl->setPersonId($personId);
+		$acl->setType($type);
+		$acl->setParticipant($participant);
+		$acl->setPermissionEdit($edit);
+		$acl->setPermissionManage($manage);
+		$newAcl = $this->aclMapper->insert($acl);
+
+		return $this->aclMapper->mapParticipant($newAcl);
+	}
+
+	/**
+	 * @param $personId
+	 * @param $aclId
+	 * @param $edit
+	 * @param $manage
+	 * @return \OCP\AppFramework\Db\Entity
+	 * @throws DoesNotExistException
+	 * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException
+	 */
+	public function updateAcl(int $personId, int $aclId, bool $edit, bool $manage) {
+		if( !$this->permissionService->personData($personId, $this->userId)) {
+			return null;
+		}
+
+		$acl = $this->aclMapper->find($aclId);
+		//[$edit, $share, $manage] = $this->applyPermissions($acl->getBoardId(), $edit, $share, $manage);
+		$acl->setPermissionEdit($edit);
+		$acl->setPermissionManage($manage);
+		$updatedAcl = $this->aclMapper->mapParticipant($this->aclMapper->update($acl));
+
+		return $updatedAcl;
+	}
+
+	/**
+	 * @param $id
+	 * @return \OCP\AppFramework\Db\Entity
+	 * @throws DoesNotExistException
+	 * @throws \OCA\Deck\NoPermissionException
+	 * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException
+	 * @throws BadRequestException
+	 */
+	public function deleteAcl(int $personId, int $aclId) {
+		if( !$this->permissionService->personData($personId, $this->userId)) {
+			return null;
+		}
+		$acl = $this->aclMapper->find($aclId);
+		$delete = $this->aclMapper->delete($acl);
+
+		return $delete;
 	}
 
 }

--- a/package.json
+++ b/package.json
@@ -31,11 +31,13 @@
 		"stylelint:fix": "stylelint src --fix"
 	},
 	"dependencies": {
+		"@nextcloud/auth": "^1.3.0",
 		"@nextcloud/axios": "^1.9.0",
 		"@nextcloud/dialogs": "^3.1.2",
 		"@nextcloud/moment": "^1.1.1",
+		"@nextcloud/router": "^2.0.0",
 		"@nextcloud/vue": "^4.3.0",
-		"@nextcloud/router": "^1.2.0",
+		"lodash.debounce": "^4.0.8",
 		"vue": "^2.6.14",
 		"vue-chartjs": "^2.8.7",
 		"vue-json-csv": "^1.2.12",

--- a/src/App.vue
+++ b/src/App.vue
@@ -4,7 +4,7 @@
 		<AppContent>
 			<div class="top-bar" />
 			<div class="content-menu-topright">
-				<Actions :title="'Details'">
+				<Actions v-if="canManage" :title="'Details'">
 					<ActionButton icon="icon-menu-sidebar" @click="$store.commit('showSidebar', !showSidebar)" />
 				</Actions>
 			</div>
@@ -22,7 +22,7 @@
 		</AppContent>
 		<AppSidebar
 			v-show="showSidebar"
-			v-if="person && !loading"
+			v-if="person && !loading && canManage"
 			:title="person.name"
 			:subtitle="t('health', 'Created at {creationTime}', { creationTime: formatMyDate(person.insertTime) })"
 			@close="$store.commit('showSidebar', false)"
@@ -34,6 +34,14 @@
 				:order="0"
 			>
 				<PersonsSidebar />
+			</AppSidebarTab>
+			<AppSidebarTab
+				id="sharing"
+				:name="t('health', 'Share')"
+				icon="icon-share"
+				:order="0.5"
+			>
+				<SharingSidebar />
 			</AppSidebarTab>
 			<AppSidebarTab
 				v-if="person.enabledModuleWeight"
@@ -100,6 +108,7 @@ import AppSidebar from '@nextcloud/vue/dist/Components/AppSidebar'
 import AppSidebarTab from '@nextcloud/vue/dist/Components/AppSidebarTab'
 import PersonsNavigation from './modules/persons/PersonsNavigation'
 import PersonsSidebar from './modules/persons/PersonsSidebar'
+import SharingSidebar from './modules/persons/SharingSidebar'
 import WeightSidebar from './modules/weight/WeightSidebar'
 import FeelingSidebar from './modules/feeling/FeelingSidebar'
 import ActionButton from '@nextcloud/vue/dist/Components/ActionButton'
@@ -137,6 +146,7 @@ export default {
 		WeightSidebar,
 		FeelingSidebar,
 		PersonsSidebar,
+		SharingSidebar,
 		WeightContent,
 		FeelingContent,
 		PersonsContent,
@@ -152,7 +162,7 @@ export default {
 	},
 	computed: {
 		...mapState(['activePersonId', 'activeModule', 'showSidebar', 'persons', 'initialLoading']),
-		...mapGetters(['person']),
+		...mapGetters(['person', 'canManage']),
 	},
 	async beforeMount() {
 		this.loading = true

--- a/src/general/DataTable.vue
+++ b/src/general/DataTable.vue
@@ -26,7 +26,7 @@
 	<div style="margin-bottom: 100px;">
 		<div v-if="loading" class="icon-loading" />
 		<ModalItem
-			v-if="!loading"
+			v-if="!loading && canEdit"
 			:header="header"
 			icon="icon-add"
 			:entity-name="entityName"
@@ -63,7 +63,7 @@
 					<th v-for="(h, i) in header" :key="i" :class="{ hide: !h.show }">
 						{{ h.name }}
 					</th>
-					<th>
+					<th v-if="canEdit">
 						{{ t('health', 'Actions', {}) }}
 					</th>
 				</tr>
@@ -120,7 +120,7 @@
 							</div>
 						</div>
 					</td>
-					<td>
+					<td v-if="canEdit">
 						<div class="inlineButtons">
 							<ModalItem
 								:id="i"
@@ -160,7 +160,7 @@
 			icon="icon-category-monitoring"
 		>
 			{{ t('health', 'No data yet') }}
-			<template #desc>
+			<template v-if="canEdit" #desc>
 				{{ t('health', 'Click at the + to add the first data.') }}
 				<ModalItem
 					:header="header"
@@ -175,6 +175,7 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
 import ModalItem from './ModalItem'
 import EmptyContent from '@nextcloud/vue/dist/Components/EmptyContent'
 import moment from '@nextcloud/moment'
@@ -224,6 +225,9 @@ export default {
 		}
 	},
 	computed: {
+		...mapGetters([
+			'canEdit',
+		]),
 		datasets() {
 			const d = []
 			// console.debug('try to return', this.data)

--- a/src/modules/persons/PersonsContent.vue
+++ b/src/modules/persons/PersonsContent.vue
@@ -25,8 +25,12 @@
 		<h2>{{ t('health', 'Welcome to your health center') }}</h2>
 		<div class="row">
 			<div class="col-2">
-				<textarea ref="mission" class="textarea-mission" :value="person.personalMission" />
-				<button
+				<textarea ref="mission"
+					class="textarea-mission"
+					:value="person.personalMission"
+					:readonly="!canEdit"
+				/>
+				<button v-if="canEdit"
 					@click="updateMission"
 				>
 					{{ t('health', 'Save ') }}
@@ -52,7 +56,7 @@ export default {
 	},
 	computed: {
 		...mapState([]),
-		...mapGetters(['person']),
+		...mapGetters(['person', 'canEdit']),
 	},
 	methods: {
 		updateMission() {

--- a/src/modules/persons/PersonsNavigation.vue
+++ b/src/modules/persons/PersonsNavigation.vue
@@ -29,14 +29,14 @@
 				:allow-collapse="true"
 				:open="(index === 0)?true:false"
 				icon="icon-user"
-				:editable="true"
+				:editable="p.permissions['PERMISSION_MANAGE']"
 				:edit-label="t('health', 'Edit name')"
 				:class="(index === activePersonId)?'active-person':''"
 				@update:menuOpen="menuOpenPersonId = index"
 				@update:title="personUpdateName"
 				@click="$store.dispatch('setActivePerson', index); $store.dispatch('setActiveModule', 'person')"
 			>
-				<template slot="actions">
+				<template v-if="p.permissions['PERMISSION_MANAGE']" slot="actions">
 					<ActionButton
 						:close-after-click="true"
 						icon="icon-details"
@@ -162,7 +162,7 @@ export default {
 	},
 	computed: {
 		...mapState(['activePersonId', 'activeModule', 'showSidebar', 'persons']),
-		...mapGetters(['person', 'personsLength']),
+		...mapGetters(['person', 'personsLength', 'canManage']),
 		getPersons() {
 			return this.persons && this.persons.length > 0
 				// eslint-disable-next-line vue/no-side-effects-in-computed-properties

--- a/src/modules/persons/PersonsNavigation.vue
+++ b/src/modules/persons/PersonsNavigation.vue
@@ -162,7 +162,7 @@ export default {
 	},
 	computed: {
 		...mapState(['activePersonId', 'activeModule', 'showSidebar', 'persons']),
-		...mapGetters(['person', 'personsLength', 'canManage']),
+		...mapGetters(['person', 'personsLength']),
 		getPersons() {
 			return this.persons && this.persons.length > 0
 				// eslint-disable-next-line vue/no-side-effects-in-computed-properties

--- a/src/modules/persons/SharingSidebar.vue
+++ b/src/modules/persons/SharingSidebar.vue
@@ -24,8 +24,8 @@
 	<div>
 		<Multiselect
 			v-if="isCurrentUser(person.userId)"
-			class="user-group-multiselect"
 			v-model="addAcl"
+			class="user-group-multiselect"
 			:placeholder="t('health', 'Share person with a user or group …')"
 			:options="formatedSharees"
 			:user-select="true"
@@ -61,7 +61,6 @@
 			<li v-for="acl in person.acl" :key="acl.id">
 				<Avatar v-if="acl.type===0" :user="acl.participant.uid" />
 				<div v-if="acl.type===1" class="avatardiv icon icon-group" />
-				<div v-if="acl.type===7" class="avatardiv icon icon-circles" />
 				<span class="has-tooltip username">
 					{{ acl.participant.displayname }}
 					<span v-if="acl.type===1">({{ t('health', 'Group') }})</span>
@@ -131,10 +130,6 @@ export default {
 
 				if (item.value.shareType === 1) {
 					sharee.icon = 'icon-group'
-					sharee.isNoUser = true
-				}
-				if (item.value.shareType === 7) {
-					sharee.icon = 'icon-circles'
 					sharee.isNoUser = true
 				}
 

--- a/src/modules/persons/SharingSidebar.vue
+++ b/src/modules/persons/SharingSidebar.vue
@@ -1,0 +1,233 @@
+<!--
+	- @copyright Copyright (c) 2020 Florian Steffens <flost-dev@mailbox.org>
+	-
+	- @author Marcus Nitzschke <mail@kendix.org>
+	-
+	- @license GNU AGPL version 3 or any later version
+	-
+	- This program is free software: you can redistribute it and/or modify
+	- it under the terms of the GNU Affero General Public License as
+	- published by the Free Software Foundation, either version 3 of the
+	- License, or (at your option) any later version.
+	-
+	- This program is distributed in the hope that it will be useful,
+	- but WITHOUT ANY WARRANTY; without even the implied warranty of
+	- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	- GNU Affero General Public License for more details.
+	-
+	- You should have received a copy of the GNU Affero General Public License
+	- along with this program. If not, see <http://www.gnu.org/licenses/>.
+	-
+	-->
+
+<template>
+	<div>
+		<Multiselect
+			v-if="isCurrentUser(person.userId)"
+			class="user-group-multiselect"
+			v-model="addAcl"
+			:placeholder="t('health', 'Share person with a user or group …')"
+			:options="formatedSharees"
+			:user-select="true"
+			label="displayName"
+			:loading="isLoading || !!isSearching"
+			:disabled="isLoading"
+			track-by="multiselectKey"
+			:internal-search="false"
+			@input="clickAddAcl"
+			@search-change="asyncFind"
+		>
+			<template #noOptions>
+				{{ isSearching ? t('health', 'Searching for users and groups …') : t('health', 'No participants found') }}
+			</template>
+			<template #noResult>
+				{{ isSearching ? t('health', 'Searching for users and groups …') : t('health', 'No participants found') }}
+			</template>
+		</Multiselect>
+
+		<ul
+			id="shareWithList"
+			class="shareWithList"
+		>
+			<li>
+				<Avatar :user="person.userId" />
+				<span class="has-tooltip username">
+					{{ person.userId }}
+					<span v-if="!isCurrentUser(person.userId)" class="person-originator-label">
+						{{ t('health', 'Originator') }}
+					</span>
+				</span>
+			</li>
+			<li v-for="acl in person.acl" :key="acl.id">
+				<Avatar v-if="acl.type===0" :user="acl.participant.uid" />
+				<div v-if="acl.type===1" class="avatardiv icon icon-group" />
+				<div v-if="acl.type===7" class="avatardiv icon icon-circles" />
+				<span class="has-tooltip username">
+					{{ acl.participant.displayname }}
+					<span v-if="acl.type===1">({{ t('health', 'Group') }})</span>
+				</span>
+
+				<ActionCheckbox v-if="isCurrentUser(acl.participant.uid) || canManage" :checked="acl.permissionEdit" @change="clickEditAcl(acl)">
+					{{ t('health', 'Can edit') }}
+				</ActionCheckbox>
+				<Actions v-if="isCurrentUser(acl.participant.uid) || canManage" :force-menu="true">
+					<ActionCheckbox :checked="acl.permissionManage" @change="clickManageAcl(acl)">
+						{{ t('health', 'Can manage') }}
+					</ActionCheckbox>
+					<ActionButton icon="icon-delete" @click="clickDeleteAcl(acl)">
+						{{ t('health', 'Delete') }}
+					</ActionButton>
+				</Actions>
+			</li>
+		</ul>
+	</div>
+</template>
+
+<script>
+import { Avatar, Multiselect, Actions, ActionButton, ActionCheckbox } from '@nextcloud/vue'
+import { mapGetters, mapState } from 'vuex'
+import { getCurrentUser } from '@nextcloud/auth'
+import { showError } from '@nextcloud/dialogs'
+import debounce from 'lodash.debounce'
+
+export default {
+	name: 'SharingSidebar',
+	components: {
+		Avatar,
+		Actions,
+		ActionButton,
+		ActionCheckbox,
+		Multiselect,
+	},
+	data() {
+		return {
+			isLoading: false,
+			isSearching: false,
+			addAcl: null,
+			addAclForAPI: null,
+			newOwner: null,
+		}
+	},
+	computed: {
+		...mapState([
+			'sharees',
+		]),
+		...mapGetters([
+			'canEdit',
+			'canManage',
+			'person',
+		]),
+		isCurrentUser() {
+			return (uid) => uid === getCurrentUser().uid
+		},
+		formatedSharees() {
+			return this.unallocatedSharees.map(item => {
+				const sharee = {
+					user: item.value.shareWith,
+					displayName: item.label,
+					icon: 'icon-user',
+					multiselectKey: item.shareType + ':' + item.primaryKey,
+				}
+
+				if (item.value.shareType === 1) {
+					sharee.icon = 'icon-group'
+					sharee.isNoUser = true
+				}
+				if (item.value.shareType === 7) {
+					sharee.icon = 'icon-circles'
+					sharee.isNoUser = true
+				}
+
+				sharee.value = item.value
+				return sharee
+			}).slice(0, 10)
+		},
+		unallocatedSharees() {
+			return this.sharees.filter((sharee) => {
+				const foundIndex = this.person.acl && this.person.acl.findIndex((acl) => {
+					return acl.participant.uid === sharee.value.shareWith && acl.participant.type === sharee.value.shareType
+				})
+				if (foundIndex === -1) {
+					return true
+				}
+				return false
+			})
+		},
+	},
+	mounted() {
+		this.asyncFind('')
+	},
+	methods: {
+		debouncedFind: debounce(async function(query) {
+			this.isSearching = true
+			await this.$store.dispatch('loadSharees', query)
+			this.isSearching = false
+		}, 300),
+		async asyncFind(query) {
+			await this.debouncedFind(query)
+		},
+		async clickAddAcl() {
+			this.addAclForAPI = {
+				type: this.addAcl.value.shareType,
+				participant: this.addAcl.value.shareWith,
+				permissionEdit: false,
+				permissionManage: false,
+			}
+			this.isLoading = true
+			try {
+				await this.$store.dispatch('addAclToCurrentPerson', this.addAclForAPI)
+			} catch (e) {
+				const errorMessage = t('health', 'Failed to create share with {displayName}', { displayName: this.addAcl.displayName })
+				console.error(errorMessage, e)
+				showError(errorMessage)
+			}
+			this.addAcl = null
+			this.isLoading = false
+		},
+		clickEditAcl(acl) {
+			this.addAclForAPI = Object.assign({}, acl)
+			this.addAclForAPI.permissionEdit = !acl.permissionEdit
+			this.$store.dispatch('updateAclFromCurrentPerson', this.addAclForAPI)
+		},
+		clickManageAcl(acl) {
+			this.addAclForAPI = Object.assign({}, acl)
+			this.addAclForAPI.permissionManage = !acl.permissionManage
+			this.$store.dispatch('updateAclFromCurrentPerson', this.addAclForAPI)
+		},
+		clickDeleteAcl(acl) {
+			this.$store.dispatch('deleteAclFromCurrentPerson', acl)
+		},
+	},
+}
+</script>
+<style scoped>
+	#shareWithList {
+		margin-bottom: 20px;
+	}
+
+	#shareWithList li {
+		display: flex;
+		align-items: center;
+	}
+
+	.username {
+		padding: 12px 9px;
+		flex-grow: 1;
+	}
+
+	.person-originator-label {
+		opacity: .7;
+	}
+
+	.avatardiv {
+		background-color: var(--color-background-dark);
+		border-radius: 16px;
+		width: 32px;
+		height: 32px;
+	}
+
+	.multiselect.user-group-multiselect {
+		display: block;
+	}
+
+</style>

--- a/src/store/PersonApi.js
+++ b/src/store/PersonApi.js
@@ -22,7 +22,7 @@
  */
 
 import axios from '@nextcloud/axios'
-import { generateUrl } from '@nextcloud/router'
+import { generateUrl, generateOcsUrl } from '@nextcloud/router'
 
 export class PersonApi {
 
@@ -134,6 +134,10 @@ export class PersonApi {
 			.catch((err) => {
 				return Promise.reject(err)
 			})
+	}
+
+	searchSharees(params) {
+		return axios.get(generateOcsUrl('apps/files_sharing/api/v1/sharees'), { params })
 	}
 
 }

--- a/src/store/PersonApi.js
+++ b/src/store/PersonApi.js
@@ -2,6 +2,7 @@
  * @copyright Copyright (c) 2020 Florian Steffens <flost-dev@mailbox.org>
  *
  * @author Florian Steffens <flost-dev@mailbox.org>
+ * @author Marcus Nitzschke <mail@kendix.org>
  *
  * @license AGPL-3.0-or-later
  *
@@ -77,6 +78,51 @@ export class PersonApi {
 
 	updateValue(personId, key, value) {
 		return axios.put(this.url(`/${personId}`), { key, value: '' + value })
+			.then(
+				(response) => {
+					return Promise.resolve(response.data)
+				},
+				(err) => {
+					return Promise.reject(err)
+				}
+			)
+			.catch((err) => {
+				return Promise.reject(err)
+			})
+	}
+
+	addAcl(acl) {
+		return axios.post(this.url(`/${acl.personId}/acl`), acl)
+			.then(
+				(response) => {
+					return Promise.resolve(response.data)
+				},
+				(err) => {
+					return Promise.reject(err)
+				}
+			)
+			.catch((err) => {
+				return Promise.reject(err)
+			})
+	}
+
+	updateAcl(acl) {
+		return axios.put(this.url(`/${acl.personId}/acl/${acl.id}`), acl)
+			.then(
+				(response) => {
+					return Promise.resolve(response.data)
+				},
+				(err) => {
+					return Promise.reject(err)
+				}
+			)
+			.catch((err) => {
+				return Promise.reject(err)
+			})
+	}
+
+	deleteAcl(acl) {
+		return axios.delete(this.url(`/${acl.personId}/acl/${acl.id}`), acl)
 			.then(
 				(response) => {
 					return Promise.resolve(response.data)

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -23,8 +23,6 @@
 
 import Vue from 'vue'
 import Vuex from 'vuex'
-import axios from '@nextcloud/axios'
-import { generateOcsUrl } from '@nextcloud/router'
 import { WeightApi } from './WeightApi'
 import { PersonApi } from './PersonApi'
 import { MeasurementApi } from './MeasurementApi'
@@ -70,10 +68,10 @@ export default new Vuex.Store({
 		person: state => (state.persons && state.persons[state.activePersonId]) ? state.persons[state.activePersonId] : null,
 		personsLength: state => state.persons ? state.persons.length : 0,
 		canEdit: state => {
-			return state.persons[state.activePersonId] ? state.persons[state.activePersonId].permissions.PERMISSION_EDIT : false
+			return state.activePersonId !== null && state.persons[state.activePersonId] ? state.persons[state.activePersonId].permissions.PERMISSION_EDIT : false
 		},
 		canManage: state => {
-			return state.persons[state.activePersonId] ? state.persons[state.activePersonId].permissions.PERMISSION_MANAGE : false
+			return state.activePersonId !== null && state.persons[state.activePersonId] ? state.persons[state.activePersonId].permissions.PERMISSION_MANAGE : false
 		},
 	},
 	mutations: {
@@ -341,10 +339,10 @@ export default new Vuex.Store({
 			params.append('search', query)
 			params.append('format', 'json')
 			params.append('perPage', 20)
-			params.append('itemType', [0, 1, 4, 7])
+			params.append('itemType', [0, 1])
 			params.append('lookup', false)
 
-			const response = await axios.get(generateOcsUrl('apps/files_sharing/api/v1/sharees'), { params })
+			const response = await personApiClient.searchSharees(params)
 			commit('setSharees', response.data.ocs.data)
 		},
 		async addAclToCurrentPerson({ dispatch, commit }, newAcl) {


### PR DESCRIPTION
- Adds the possibility to share persons between users and groups
- There are three different permission levels:
  - read: User/group is allowed to read the data of the person
  - edit: User/group is allowed to add/update data entries
  - manage: User/group is allowed to manage the settings of the person
- Implementation is based on the implementation in the `deck` app